### PR TITLE
Add "killAppIfNeeded" function

### DIFF
--- a/android/src/main/java/com/reactnativechangeicon/ChangeIconModule.java
+++ b/android/src/main/java/com/reactnativechangeicon/ChangeIconModule.java
@@ -99,7 +99,7 @@ public class ChangeIconModule extends ReactContextBaseJavaModule implements Appl
 
     @ReactMethod
     public void killAppIfNeeded(Promise promise) {
-        if (!iconChanged || classesToKill.length === 0) {
+        if (!iconChanged || classesToKill.size() === 0) {
             promise.resolve(false);
             return;
         }

--- a/android/src/main/java/com/reactnativechangeicon/ChangeIconModule.java
+++ b/android/src/main/java/com/reactnativechangeicon/ChangeIconModule.java
@@ -99,7 +99,7 @@ public class ChangeIconModule extends ReactContextBaseJavaModule implements Appl
 
     @ReactMethod
     public void killAppIfNeeded(Promise promise) {
-        if (!iconChanged || classesToKill.size() === 0) {
+        if (!iconChanged || classesToKill.size() == 0) {
             promise.resolve(false);
             return;
         }

--- a/android/src/main/java/com/reactnativechangeicon/ChangeIconModule.java
+++ b/android/src/main/java/com/reactnativechangeicon/ChangeIconModule.java
@@ -97,6 +97,17 @@ public class ChangeIconModule extends ReactContextBaseJavaModule implements Appl
         iconChanged = true;
     }
 
+    @ReactMethod
+    public void killAppIfNeeded(Promise promise) {
+        if (!iconChanged || classesToKill.length === 0) {
+            promise.resolve(false);
+            return;
+        }
+
+        completeIconChange();
+        promise.resolve(true);
+    }
+
     private void completeIconChange() {
         if (!iconChanged) return;
         final Activity activity = getCurrentActivity();

--- a/index.js
+++ b/index.js
@@ -4,4 +4,13 @@ const changeIcon = (iconName) => NativeModules.ChangeIcon.changeIcon(iconName);
 
 const getIcon = () => NativeModules.ChangeIcon.getIcon();
 
-export { changeIcon, getIcon };
+const killAppIfNeeded = () => {
+    if (Platform.OS === "android") {
+        return NativeModules.ChangeIcon.killAppIfNeeded();
+    } else {
+        // iOS never needs to kill the app
+        return Promise.resolve(false);
+    }
+};
+
+export { changeIcon, getIcon, killAppIfNeeded };


### PR DESCRIPTION
I think it's very unexpected that the app would be killed upon backgrounding (potentially loosing the user's current state).
I'd much rather kill the app immediately, so they know what's going on.
I considered adding an argument to `changeIcon` to kill immediately, but this seems a little more flexible,
and doesn't involve changing the signature of any existing methods.